### PR TITLE
Implement playback preview for saved recordings

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -16,6 +16,9 @@
       <SelectionState runConfigName="OpusEncoderActivity">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="SavedRecordingsScreenPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/theimpartialai/speechScribe/model/RecordingItemState.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/model/RecordingItemState.kt
@@ -1,0 +1,9 @@
+package com.theimpartialai.speechScribe.model
+
+import com.theimpartialai.speechScribe.ui.savedRecording.PlayBackState
+import kotlinx.coroutines.flow.MutableStateFlow
+
+data class RecordingItemState(
+    val recording: AudioRecording,
+    val playbackState: MutableStateFlow<PlayBackState> = MutableStateFlow(PlayBackState.Pause)
+)

--- a/app/src/main/java/com/theimpartialai/speechScribe/model/RecordingItemState.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/model/RecordingItemState.kt
@@ -1,9 +1,0 @@
-package com.theimpartialai.speechScribe.model
-
-import com.theimpartialai.speechScribe.ui.savedRecording.PlayBackState
-import kotlinx.coroutines.flow.MutableStateFlow
-
-data class RecordingItemState(
-    val recording: AudioRecording,
-    val playbackState: MutableStateFlow<PlayBackState> = MutableStateFlow(PlayBackState.Pause)
-)

--- a/app/src/main/java/com/theimpartialai/speechScribe/repository/AudioRecordingImpl.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/repository/AudioRecordingImpl.kt
@@ -1,12 +1,23 @@
 package com.theimpartialai.speechScribe.repository
 
 import android.content.Context
+import android.media.AudioAttributes
 import android.media.MediaMetadataRetriever
+import android.media.MediaPlayer
+import android.net.Uri
+import android.util.Log
 import com.theimpartialai.speechScribe.model.AudioRecording
 import com.theimpartialai.speechScribe.opusEncoding.utils.FileUtils.getOutputDirectory
+import com.theimpartialai.speechScribe.ui.savedRecording.PlayBackState
 import java.io.File
 
+
 class AudioRecordingImpl : AudioRecordingInterface {
+    private var mediaPlayer: MediaPlayer? = null
+    private var currentRecording: AudioRecording? = null
+    private var pauseLength = 0
+    private var playbackIsFinished = false
+
     override suspend fun loadRecordings(context: Context): List<AudioRecording> {
         val outputDir = getOutputDirectory(context)
         val recordings = getRecordingsFromDirectory(outputDir)
@@ -41,6 +52,59 @@ class AudioRecordingImpl : AudioRecordingInterface {
         }
     }
 
+    override suspend fun togglePlayback(
+        context: Context,
+        recording: AudioRecording,
+        playBackState: PlayBackState,
+        onPlayBackComplete: (PlayBackState) -> Unit,
+    ) {
+        try {
+            if (mediaPlayer == null || currentRecording?.filePath != recording.filePath) {
+                // Initialize MediaPlayer with the new recording
+                mediaPlayer?.release()
+                mediaPlayer = MediaPlayer().apply {
+                    setAudioAttributes(
+                        AudioAttributes.Builder()
+                            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .build()
+                    )
+                    setDataSource(context, Uri.fromFile(File(recording.filePath)))
+                    prepare()
+                    setOnCompletionListener {
+                        pauseLength = 0
+                        playbackIsFinished = true
+                        mediaPlayer?.release()
+                        mediaPlayer = null
+                        onPlayBackComplete(PlayBackState.Play)
+                    }
+                }
+                currentRecording = recording
+                pauseLength = 0
+            }
+            when (playBackState) {
+                is PlayBackState.Play -> {
+                    mediaPlayer?.apply {
+                        seekTo(pauseLength)
+                        start()
+                    }
+                }
+
+                is PlayBackState.Pause -> {
+                    mediaPlayer?.apply {
+                        pauseLength = if (playbackIsFinished) {
+                            0
+                        } else {
+                            currentPosition
+                        }
+                        pause()
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("AudioRecordingImpl", "Error playing recording: ${e.message}")
+        }
+    }
 
     override suspend fun deleteRecording(recording: AudioRecording) {
         val file = File(recording.filePath)

--- a/app/src/main/java/com/theimpartialai/speechScribe/repository/AudioRecordingInterface.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/repository/AudioRecordingInterface.kt
@@ -2,8 +2,15 @@ package com.theimpartialai.speechScribe.repository
 
 import android.content.Context
 import com.theimpartialai.speechScribe.model.AudioRecording
+import com.theimpartialai.speechScribe.ui.savedRecording.PlayBackState
 
 interface AudioRecordingInterface {
     suspend fun loadRecordings(context: Context): List<AudioRecording>
     suspend fun deleteRecording(recording: AudioRecording)
+    suspend fun togglePlayback(
+        context: Context,
+        recording: AudioRecording,
+        playBackState: PlayBackState,
+        onPlayBackComplete: (PlayBackState) -> Unit,
+    )
 }

--- a/app/src/main/java/com/theimpartialai/speechScribe/ui/components/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/ui/components/navigation/NavigationGraph.kt
@@ -31,7 +31,9 @@ fun NavigationGraph(
 
             val context = LocalContext.current
             val recordings by savedRecordingsViewModel.recordings.collectAsState()
-                val playBackState = savedRecordingsViewModel.playBackState
+            val playBackState = savedRecordingsViewModel.playBackState
+            val currentlyPlayingItem by savedRecordingsViewModel.currentlyPlayingItem.collectAsState()
+
 
             LaunchedEffect(Unit) {
                 savedRecordingsViewModel.loadRecordings(context)
@@ -42,10 +44,11 @@ fun NavigationGraph(
                 onDelete = { savedRecordingsViewModel.deleteRecording(it) },
                 onTogglePlayback = { recording, isPaused ->
                     savedRecordingsViewModel.playRecording(context, recording, isPaused)
-//                    savedRecordingsViewModel.updatePlaybackState(isPaused)
                 },
                 onMoreOptions = {},
-                playBackState = playBackState
+                playBackState = playBackState,
+                currentlyPlayingItem = currentlyPlayingItem,
+                onPlaybackComplete = { savedRecordingsViewModel.onPlaybackComplete() }
             )
         }
 

--- a/app/src/main/java/com/theimpartialai/speechScribe/ui/components/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/ui/components/navigation/NavigationGraph.kt
@@ -31,6 +31,7 @@ fun NavigationGraph(
 
             val context = LocalContext.current
             val recordings by savedRecordingsViewModel.recordings.collectAsState()
+                val playBackState = savedRecordingsViewModel.playBackState
 
             LaunchedEffect(Unit) {
                 savedRecordingsViewModel.loadRecordings(context)
@@ -39,8 +40,12 @@ fun NavigationGraph(
             SavedRecordingsScreen(
                 recordings = recordings,
                 onDelete = { savedRecordingsViewModel.deleteRecording(it) },
-                onPlay = {},
-                onMoreOptions = {}
+                onTogglePlayback = { recording, isPaused ->
+                    savedRecordingsViewModel.playRecording(context, recording, isPaused)
+//                    savedRecordingsViewModel.updatePlaybackState(isPaused)
+                },
+                onMoreOptions = {},
+                playBackState = playBackState
             )
         }
 

--- a/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreen.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreen.kt
@@ -173,6 +173,7 @@ fun RecordingItem(
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                // TODO: Uncomment the following lines when I figure out how to format the duration for Opus files
 //                Text(
 //                    text = recording.formattedDuration,
 //                    style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreenViewModel.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreenViewModel.kt
@@ -38,27 +38,6 @@ class SavedRecordingsViewModel : ViewModel() {
         }
     }
 
-//    fun playRecording(context: Context, recording: AudioRecording, isPaused: PlayBackState) {
-//        viewModelScope.launch {
-//            audioRepository.togglePlayback(context, recording, isPaused) { newPlayBackState ->
-//                _playbackState.value = newPlayBackState
-//            }
-//        }
-//    }
-
-    fun playRecording3(context: Context, recording: AudioRecording, isPaused: PlayBackState) {
-        viewModelScope.launch {
-            audioRepository.togglePlayback(context, recording, isPaused) { newPlayBackState ->
-                _playbackState.value = newPlayBackState
-                if (newPlayBackState == PlayBackState.Play) {
-                    _currentlyPlayingItem.value = recording
-                } else if (newPlayBackState == PlayBackState.Pause) {
-                    _currentlyPlayingItem.value = null
-                }
-            }
-        }
-    }
-
     fun playRecording(context: Context, recording: AudioRecording, playBackState: PlayBackState) {
         viewModelScope.launch {
             audioRepository.togglePlayback(context, recording, playBackState) { newPlayBackState ->

--- a/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreenViewModel.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreenViewModel.kt
@@ -18,6 +18,9 @@ class SavedRecordingsViewModel : ViewModel() {
     private val _playbackState = MutableStateFlow<PlayBackState>(PlayBackState.Pause)
     val playBackState: StateFlow<PlayBackState> get() = _playbackState
 
+    private val _currentlyPlayingItem = MutableStateFlow<AudioRecording?>(null)
+    val currentlyPlayingItem: StateFlow<AudioRecording?> = _currentlyPlayingItem
+
     fun loadRecordings(context: Context) {
         viewModelScope.launch {
             val recordings = audioRepository.loadRecordings(context)
@@ -35,12 +38,43 @@ class SavedRecordingsViewModel : ViewModel() {
         }
     }
 
-    fun playRecording(context: Context, recording: AudioRecording, isPaused: PlayBackState) {
+//    fun playRecording(context: Context, recording: AudioRecording, isPaused: PlayBackState) {
+//        viewModelScope.launch {
+//            audioRepository.togglePlayback(context, recording, isPaused) { newPlayBackState ->
+//                _playbackState.value = newPlayBackState
+//            }
+//        }
+//    }
+
+    fun playRecording3(context: Context, recording: AudioRecording, isPaused: PlayBackState) {
         viewModelScope.launch {
             audioRepository.togglePlayback(context, recording, isPaused) { newPlayBackState ->
                 _playbackState.value = newPlayBackState
+                if (newPlayBackState == PlayBackState.Play) {
+                    _currentlyPlayingItem.value = recording
+                } else if (newPlayBackState == PlayBackState.Pause) {
+                    _currentlyPlayingItem.value = null
+                }
             }
         }
+    }
+
+    fun playRecording(context: Context, recording: AudioRecording, playBackState: PlayBackState) {
+        viewModelScope.launch {
+            audioRepository.togglePlayback(context, recording, playBackState) { newPlayBackState ->
+                _playbackState.value = newPlayBackState
+                if (newPlayBackState == PlayBackState.Play) {
+                    _currentlyPlayingItem.value = recording
+                } else {
+                    _currentlyPlayingItem.value = null
+                }
+            }
+        }
+    }
+
+    fun onPlaybackComplete() {
+        _playbackState.value = PlayBackState.Pause
+        _currentlyPlayingItem.value = null
     }
 }
 

--- a/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreenViewModel.kt
+++ b/app/src/main/java/com/theimpartialai/speechScribe/ui/savedRecording/SavedRecordingsScreenViewModel.kt
@@ -15,6 +15,9 @@ class SavedRecordingsViewModel : ViewModel() {
     private val _recordings = MutableStateFlow<List<AudioRecording>>(emptyList())
     val recordings: StateFlow<List<AudioRecording>> get() = _recordings
 
+    private val _playbackState = MutableStateFlow<PlayBackState>(PlayBackState.Pause)
+    val playBackState: StateFlow<PlayBackState> get() = _playbackState
+
     fun loadRecordings(context: Context) {
         viewModelScope.launch {
             val recordings = audioRepository.loadRecordings(context)
@@ -31,4 +34,17 @@ class SavedRecordingsViewModel : ViewModel() {
             _recordings.value = updatedList
         }
     }
+
+    fun playRecording(context: Context, recording: AudioRecording, isPaused: PlayBackState) {
+        viewModelScope.launch {
+            audioRepository.togglePlayback(context, recording, isPaused) { newPlayBackState ->
+                _playbackState.value = newPlayBackState
+            }
+        }
+    }
+}
+
+sealed class PlayBackState {
+    data object Play : PlayBackState()
+    data object Pause : PlayBackState()
 }

--- a/app/src/main/res/drawable/play_icon.xml
+++ b/app/src/main/res/drawable/play_icon.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="80dp" android:viewportHeight="7" android:viewportWidth="7" android:width="80dp">
+      
+    <path android:fillColor="#000000" android:fillType="evenOdd" android:pathData="M5.9948,2.5732L2.0008,0.1421C1.3321,-0.2646 0.5,0.25 0.5,1.0688L0.5,5.9309C0.5,6.751 1.3321,7.2644 2.0008,6.8577L5.9948,4.4277C6.6684,4.0178 6.6684,2.9832 5.9948,2.5732" android:strokeColor="#00000000" android:strokeWidth="1"/>
+    
+</vector>


### PR DESCRIPTION
This PR introduces playback preview functionality for the saved recordings. The changes focus on the state managment of the playback in order to allow the user to play and pause the audio to preview the recording.

### Changes:
- Added  `togglePlayback` that uses `MediaPlayer` to handle the recording playback ( Play and pause). It also adds logic to handle playback state transitions and implements a completion listener to reset the playback position and release resources upon completion.
- Added `playRecording ` function in SavedRecordingsViewModel to manage the playback state and currently playing item.
- Update the SavedScreen based current state to change the icons and trigger playback.



| Video| Description |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/f797ba51-5115-48a7-82a2-17315b34f2b0" controls width="250">  | Recording playback preview and UI updates. |




### Notes:
( Challenges and reflection):

This feature was somewhat tricky because each `RecordingItem` in the list required a unique **Per-Item state** to update the icon and execute playback. In other words, only the `RecordingItem`whose playback state changes should recompose.

- Additionally, efficient recomposition for  `RecordingItem` needed to be handled in two scenarios:

- When the user clicks on the icon, it should immediately trigger UI recomposition and manage playback functionality
- When playback completes, it should trigger UI recomposition and handle playback functionality.

Another challenge was to resume and pause playback while maintaining the duration for each recording.


### Feature work

- Explore a more readable way to handle state, possibly using a pair and leveraging a map to wrap some states from the ViewModel.
- Extract the duration from the Opus file, as the current Android library does not support the Opus format. 🫤 